### PR TITLE
Fix bad href for assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Open the `views/layout.erb` file in Sublime Text and copy/paste this boilerplate
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="application.css">
+    <link rel="stylesheet" href="/application.css">
   </head>
   <body>
 
@@ -334,7 +334,7 @@ Open the `views/layout.erb` file in Sublime Text and copy/paste this boilerplate
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
-    <script src="application.js"></script>
+    <script src="/application.js"></script>
   </body>
 </html>
 ```


### PR DESCRIPTION
Local Stylesheets and Javascripts files are linked with

```
<link rel="stylesheet" href="application.css">
```

and 

```
<script src="application.js"></script>
```

Everything is working nicely most of the time, but in fact some requests where failing when route has more than one level.

* On `/foo`, requests for JS and CSS are done to `http://localhost:4567/application.css` and `http://localhost:4567/application.js`, nice.

* On `/destroy/:index`, requests are done to `http://localhost:4567/destroy/application.css` and `http://localhost:4567/application.js` (because of the missing `/`), then the code behind this route was executed three times (resulting in a strange triple delete for one of my student).

This PR fix this behavior
