### PR TITLE
Use `brew install --cask ngrok` on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ If you want to share your app with people outside the local network (someone at 
 On OSX, you can get it with:
 
 ```bash
-brew cask install ngrok
+brew install --cask ngrok
 ```
 
 (On Ubuntu, you'll have to download it manually, [follow the tutorial](https://ngrok.com/download))


### PR DESCRIPTION
brew cask commands were deprecated in Homebrew 2.6.0.