### PR TITLE
adressed issue #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,17 @@ Open this `Gemfile` in Sublime Text (`stt`) and copy-paste this code:
 ```ruby
 source "https://rubygems.org"
 
+gem "thin"
 gem "sinatra"
 gem "sinatra-contrib"
 gem "pry-byebug"
 gem "better_errors"
 gem "binding_of_caller"
+```
+
+For windows user, in the terminal, run:
+```bash
+sudo apt-get install build-essential
 ```
 
 In the terminal, run the following command to fetch the gems specified in the `Gemfile`:


### PR DESCRIPTION
I updated the README.md to address issue #9.
issue #9: : Server handler (thin,puma,reel,HTTP,webrick) not found. (RuntimeError)
adding `gem "thin"` to the Gemfile fixes the problem on Mac. On windows an extra `sudo apt-get install build-essential` is necessary